### PR TITLE
[Resolves #1]  Fixes transform_dicts KeyError using Registry 

### DIFF
--- a/tests/fixtures/data/patients_dirty_missing_key.json
+++ b/tests/fixtures/data/patients_dirty_missing_key.json
@@ -1,0 +1,4 @@
+[{"mrn": "C", "name": "Josh Winston"},
+ {"mrn": "A", "name": "Ben Sullivan", "age": 35},
+ {"mrn": "B", "name": "Emery Redmond", "age": 18}
+]

--- a/tests/fixtures/data/patients_missing_key_clean.py
+++ b/tests/fixtures/data/patients_missing_key_clean.py
@@ -1,0 +1,16 @@
+data = [
+        {
+            "mrn": "C", 
+            "name": "Josh Winston"
+        },
+        {
+            "mrn": "A", 
+            "name": "Ben Sullivan", 
+            "age": 35
+        },
+        {
+            "mrn": "B", 
+            "name": "Emery Redmond", 
+            "age": 18
+        }
+        ]

--- a/thecurator/__init__.py
+++ b/thecurator/__init__.py
@@ -82,7 +82,7 @@ class Curator():
         Returns:
             :obj:`list` of :obj:`dict`: Transformed dicts
         """
-        column_names = raw_rows[0].keys()
+        column_names = self.table_registry.get_table(table_name)['columns_by_name'].keys()
         transforms_by_column = {}
         for column_name in column_names:
             transforms_by_column[column_name] = \


### PR DESCRIPTION
# Fixes transform_dicts KeyError using Registry 
[ Resolves #1 ]

## Issue

This fixes a `KeyError` in `curator.transform_dicts()` that occurs when the first record of incoming data is missing a key expected by the remaining records.  This causes population of the list of column transforms to be missing the transform associated with the missing key.  When `transform_dicts()` reaches a row where that key is present and attempts to apply the transform that's missing, a `KeyError` results.

## Resolution

Instead of retrieving the list of columns transforms from the first record of the incoming data, it's now pulled from the total column list of the associated table in the Registry.
